### PR TITLE
Accept int64 VtValue for TYPE_INT with checked narrowing - Houdini 21

### DIFF
--- a/lib/hydramoonray/ValueConverter.cc
+++ b/lib/hydramoonray/ValueConverter.cc
@@ -5,6 +5,9 @@
 
 #include <scene_rdl2/render/logging/logging.h>
 
+#include <cstdint>
+#include <limits>
+
 #include <pxr/usd/sdf/assetPath.h>
 
 namespace hdMoonray {
@@ -15,6 +18,39 @@ static void _clearBinding(SceneObject* sceneObj, const Attribute* attribute)
 {
     if (attribute->isBindable())
         sceneObj->setBinding(*attribute,nullptr);
+}
+
+static bool _extractIntegral64(const pxr::VtValue& val, std::int64_t* out)
+{
+    if (val.IsHolding<int>()) {
+        *out = static_cast<std::int64_t>(val.UncheckedGet<int>());
+        return true;
+    }
+    if (val.IsHolding<long>()) {
+        *out = static_cast<std::int64_t>(val.UncheckedGet<long>());
+        return true;
+    }
+    if (val.IsHolding<long long>()) {
+        *out = static_cast<std::int64_t>(val.UncheckedGet<long long>());
+        return true;
+    }
+    return false;
+}
+
+static bool _narrowIntChecked(SceneObject* sceneObj,
+                              const Attribute* attribute,
+                              std::int64_t value,
+                              Int* out)
+{
+    constexpr std::int64_t kMin = static_cast<std::int64_t>(std::numeric_limits<Int>::min());
+    constexpr std::int64_t kMax = static_cast<std::int64_t>(std::numeric_limits<Int>::max());
+    if (value < kMin || value > kMax) {
+        Logger::error(sceneObj->getName(), '.', attribute->getName(),
+                      ": integer value ", value, " out of Int range [", kMin, ", ", kMax, "]");
+        return false;
+    }
+    *out = static_cast<Int>(value);
+    return true;
 }
 
 template<typename T>
@@ -144,10 +180,15 @@ ValueConverter::setAttribute(SceneObject* sceneObj, const Attribute* attribute, 
                 key = &(val.UncheckedGet<pxr::TfToken>().GetString());
             } else if (val.IsHolding<std::string>()) {
                 key = &(val.UncheckedGet<std::string>());
-            } else if (val.IsHolding<long>() || val.IsHolding<int>()) {
-                const int intVal = val.IsHolding<long>() ?
-                                   static_cast<int>(val.UncheckedGet<long>()) :
-                                   val.UncheckedGet<int>();
+            } else {
+                std::int64_t int64Val = 0;
+                if (!_extractIntegral64(val, &int64Val)) {
+                    break; // go print normal error message
+                }
+                Int intVal = 0;
+                if (!_narrowIntChecked(sceneObj, attribute, int64Val, &intVal)) {
+                    return;
+                }
                 int index = 0;
                 for (auto it = attribute->beginEnumValues(); it != attribute->endEnumValues(); ++it) {
                     if (index == intVal) {
@@ -157,8 +198,6 @@ ValueConverter::setAttribute(SceneObject* sceneObj, const Attribute* attribute, 
                     ++index;
                 }
                 break;
-            } else {
-                break; // go print normal error message
             }
             for (auto it = attribute->beginEnumValues(); it != attribute->endEnumValues(); ++it) {
                 if (it->second == *key) {
@@ -170,10 +209,16 @@ ValueConverter::setAttribute(SceneObject* sceneObj, const Attribute* attribute, 
             Logger::error(sceneObj->getName(), '.', attribute->getName(),
                           ": Invalid enum key '", *key, "'");
             return;
-        } else  if (val.IsHolding<long>()) {
-            sceneObj->set(AttributeKey<Int>(*attribute), static_cast<int>(val.UncheckedGet<long>()));
-            return;
         } else {
+            std::int64_t int64Val = 0;
+            if (_extractIntegral64(val, &int64Val)) {
+                Int intVal = 0;
+                if (!_narrowIntChecked(sceneObj, attribute, int64Val, &intVal)) {
+                    return;
+                }
+                sceneObj->set(AttributeKey<Int>(*attribute), intVal);
+                return;
+            }
             if (_setAttributeRef<Int, int>(sceneObj, attribute, val)) return;
         }
         break;


### PR DESCRIPTION
## Compatibility:
build

## Issues/Tickets:
- Related OpenMoonRay PR: https://github.com/dreamworksanimation/openmoonray/pull/228

## Release notes comment:
Fixes Houdini 21 SceneVariables integer conversion by accepting 64-bit integer inputs for `TYPE_INT` attributes in `ValueConverter`.

## Comments for the reviewer:
- This PR updates `lib/hydramoonray/ValueConverter.cc`.
- It fixes a Houdini 21 / Solaris integration issue where MoonRay received 64-bit integer values for `__SceneVariables__` attributes that expect `TYPE_INT`.
- Before this change, MoonRay emitted repeated errors such as:
  - `__SceneVariables__.* cannot convert long long to Int`
- The fix adds:
  - 64-bit integer extraction for integral inputs
  - checked narrowing into MoonRay `Int`
  - enum index handling from 64-bit integer inputs
- Scope is intentionally narrow:
  - only `TYPE_INT` conversion behavior is updated
  - all other type paths remain unchanged

## Look or scene setup change:
No intended look change. This is a Houdini/MoonRay value-conversion compatibility fix.

## Special notes for production:
- This PR is intended to support Houdini 21.x Solaris/MoonRay workflows.
- It removes repeated `long long -> Int` conversion failures for SceneVariables in Houdini 21.
- No dependency or scene-format changes are intended.

## Attention/Reviewers:

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.